### PR TITLE
Get rrd-sys building in docsrs

### DIFF
--- a/librrd-sys/build.rs
+++ b/librrd-sys/build.rs
@@ -1,12 +1,13 @@
 use std::{env, path::{Path, PathBuf}};
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(rrdsys_use_pregen)");
+
     if env::var("DOCS_RS").is_ok() {
-        // Nothing to do
+        println!("cargo::rustc-cfg=rrdsys_use_pregen");
         return;
     }
 
-    println!("cargo::rustc-check-cfg=cfg(rrdsys_use_pregen)");
     if let Some(location) = configure_rrd() {
         create_bindings(location);
     } else {

--- a/librrd-sys/src/lib.rs
+++ b/librrd-sys/src/lib.rs
@@ -1,3 +1,7 @@
+//! This exposes `bindgen` bindings to [`librrd`](https://oss.oetiker.ch/rrdtool/index.en.html).
+//!
+//! For a high level library built on top of this, see [`rrd`](https://crates.io/crates/rrd).
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Turns out local docs.rs could reproduce the current build error; I just wasn't looking in the right place. This worked locally for me.