### PR TITLE
fix: make lifetime parameters explicit in return types

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -67,7 +67,7 @@ where
     }
 
     /// The rows of data in the dataset.
-    pub fn rows(&self) -> Rows<T> {
+    pub fn rows(&self) -> Rows<'_, T> {
         Rows { data: self }
     }
 }
@@ -197,7 +197,7 @@ where
     }
 
     /// Iterate over the [`Cell`]s for this row's values.
-    pub fn iter_cells(&self) -> impl Iterator<Item = Cell> {
+    pub fn iter_cells(&self) -> impl Iterator<Item = Cell<'_>> {
         self.data
             .names
             .iter()


### PR DESCRIPTION
Resolve compiler warnings about mismatched lifetime syntaxes by making lifetime parameters explicit in function return types.

The compiler warned that lifetimes were being elided in `&self` but hidden in the return types `Rows<T>` and `Cell`, creating confusing signatures. By using `'_` in the return types (`Rows<'_, T>` and `Cell<'_>`), the lifetime relationship becomes clear and consistent.

This follows Rust's best practice of making lifetimes explicit when they appear in both elided and non-elided forms, improving code clarity and eliminating the `mismatched_lifetime_syntaxes` warnings.

Changes:
- Data::rows(): Rows<T> -> Rows<'_, T>
- Row::iter_cells(): impl Iterator<Item = Cell> -> impl Iterator<Item = Cell<'_>>