### PR TITLE
Make chrono dependency optional

### DIFF
--- a/.github/actions/quick-check/action.yaml
+++ b/.github/actions/quick-check/action.yaml
@@ -37,3 +37,8 @@ runs:
       shell: bash
       env:
         CARGO_TERM_COLOR: always
+    - name: Run tests without chrono
+      run: cargo test --no-default-features
+      shell: bash
+      env:
+        CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rrd-sys = { version = "0.1.3", path = "librrd-sys" }
 
 bitflags = "2.8.0"
 thiserror = "2.0.11"
-chrono = "0.4.39"
+chrono = { version = "0.4.39", optional = true }
 log = "0.4.25"
 regex = "1.11.1"
 itertools = "0.14.0"
@@ -37,3 +37,4 @@ env_logger = "0.11"
 [features]
 # Adds support for specifying locking mode when updating RRDs (available since rrdtool 1.9.0)
 locking_mode = []
+default = ["chrono"]

--- a/examples/rrd-create.rs
+++ b/examples/rrd-create.rs
@@ -2,9 +2,15 @@ use rrd::{ops::create, ConsolidationFn};
 use std::{path::Path, time::Duration};
 
 fn main() {
+    #[cfg(feature = "chrono")]
+    let start = chrono::Utc::now();
+
+    #[cfg(not(feature = "chrono"))]
+    let start = std::time::SystemTime::now();
+
     let rc = create::create(
         Path::new("db.rrd"),
-        chrono::Utc::now(),
+        start,
         Duration::from_secs(1),
         false,
         None,

--- a/examples/rrd-fetch.rs
+++ b/examples/rrd-fetch.rs
@@ -7,12 +7,20 @@ use rrd::{
 
 fn main() {
     let filename = Path::new("db.rrd");
+
+    #[cfg(feature = "chrono")]
     let start = chrono::Utc::now();
+    #[cfg(feature = "chrono")]
     let end = start + chrono::TimeDelta::seconds(300);
+
+    #[cfg(not(feature = "chrono"))]
+    let start = std::time::SystemTime::now();
+    #[cfg(not(feature = "chrono"))]
+    let end = start + Duration::from_secs(300);
 
     create::create(
         filename,
-        start - chrono::TimeDelta::seconds(1),
+        start - Duration::from_secs(1),
         Duration::from_secs(1),
         false,
         None,
@@ -61,8 +69,8 @@ fn main() {
     match rc {
         Ok(data) => {
             println!("Ok");
-            println!("  Start: {}", data.start());
-            println!("  End: {}", data.end());
+            println!("  Start: {:?}", data.start());
+            println!("  End: {:?}", data.end());
             println!("  Step: {:?}", data.step());
             println!("  Rows: {}", data.row_count());
 
@@ -75,7 +83,7 @@ fn main() {
             println!("  Rows: {}", rows.len());
             for (i, row) in rows.iter().enumerate() {
                 println!(
-                    "    #{:03}: {} - {:.03}, {:.03}",
+                    "    #{:03}: {:?} - {:.03}, {:.03}",
                     i,
                     row.timestamp(),
                     row[0],

--- a/examples/rrd-update.rs
+++ b/examples/rrd-update.rs
@@ -7,9 +7,15 @@ use std::{path::Path, time::Duration};
 fn main() {
     let filename = Path::new("db.rrd");
 
+    #[cfg(feature = "chrono")]
+    let start = chrono::Utc::now();
+
+    #[cfg(not(feature = "chrono"))]
+    let start = std::time::SystemTime::now();
+
     create::create(
         filename,
-        chrono::Utc::now(),
+        start,
         Duration::from_secs(1),
         false,
         None,

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,6 +1,6 @@
 //! Support for navigating fetched data sets.
 
-use crate::Timestamp;
+use crate::{Timestamp, TimestampExt};
 use rrd_sys::rrd_double;
 use std::{fmt, ops::Deref, time::Duration};
 
@@ -236,7 +236,7 @@ where
 
         f.debug_struct("Row")
             .field("ts", &self.timestamp)
-            .field("ts_int", &self.timestamp.timestamp())
+            .field("ts_int", &self.timestamp.as_time_t())
             .field(
                 "data",
                 &RowDataDebug {

--- a/src/ops/create.rs
+++ b/src/ops/create.rs
@@ -42,7 +42,7 @@ pub fn create<'a>(
 
     debug!(
         "Create: file={filename:?} start={} step={} no_overwrite={no_overwrite} template={template:?} sources={sources:?} args={args:?}",
-        start.timestamp(),
+        start.as_time_t(),
         step.as_secs()
     );
 

--- a/src/ops/fetch.rs
+++ b/src/ops/fetch.rs
@@ -65,14 +65,12 @@ pub fn fetch(
     assert!(resolution > 0);
 
     // Move forward one step -- first timestamp's data is included in the time that ends one step ahead
-    let start = Timestamp::from_timestamp(
+    let start = Timestamp::from_time_t(
         start
             .checked_add(i64::try_from(resolution).expect("Resolution i64 overflow"))
             .expect("Start overflow"),
-        0,
-    )
-    .expect("Impossible start");
-    let end = Timestamp::from_timestamp(end, 0).expect("Impossible end");
+    );
+    let end = Timestamp::from_time_t(end);
 
     let ds_count_usize = ds_count.try_into().expect("Count overflow");
 
@@ -90,8 +88,8 @@ pub fn fetch(
     };
 
     let rows = (usize::try_from(
-        end.timestamp()
-            .checked_sub(start.timestamp())
+        end.as_time_t()
+            .checked_sub(start.as_time_t())
             .expect("Negative time range"),
     )
     .expect("Time range overflow")

--- a/src/ops/graph/elements.rs
+++ b/src/ops/graph/elements.rs
@@ -25,7 +25,7 @@ use crate::{
     error::{InvalidArgument, RrdResult},
     ops::graph::{AppendArgs, Color},
     util::path_to_str,
-    ConsolidationFn, Timestamp,
+    ConsolidationFn, Timestamp, TimestampExt,
 };
 use itertools::Itertools;
 use std::{fmt::Write as _, path::PathBuf, sync};
@@ -103,10 +103,10 @@ impl AppendArgs for Def {
             write!(s, ":step={step}").unwrap();
         }
         if let Some(start) = self.start {
-            write!(s, ":start={}", start.timestamp()).unwrap();
+            write!(s, ":start={}", start.as_time_t()).unwrap();
         }
         if let Some(end) = self.end {
-            write!(s, ":end={}", end.timestamp()).unwrap();
+            write!(s, ":end={}", end.as_time_t()).unwrap();
         }
         if let Some(reduce) = self.reduce {
             write!(s, ":reduce={}", reduce.as_arg_str()).unwrap();
@@ -355,7 +355,7 @@ impl Value {
     fn append_to(&self, s: &mut String) {
         match self {
             Value::Variable(v) => write!(s, "{}", v.name),
-            Value::Timestamp(t) => write!(s, "{}", t.timestamp()),
+            Value::Timestamp(t) => write!(s, "{}", t.as_time_t()),
             Value::Constant(f) => {
                 write!(s, "{}", f)
             }
@@ -768,8 +768,8 @@ mod tests {
             ds_name: "DS1".to_string(),
             consolidation_fn: ConsolidationFn::Avg,
             step: Some(1),
-            start: Some(chrono::DateTime::from_timestamp(100, 0).unwrap()),
-            end: Some(chrono::DateTime::from_timestamp(1000, 0).unwrap()),
+            start: Some(Timestamp::from_time_t(100)),
+            end: Some(Timestamp::from_time_t(1000)),
             reduce: Some(ConsolidationFn::Max),
         }
         .append_to(&mut args)
@@ -886,7 +886,7 @@ mod tests {
     fn hrule() {
         let mut args = vec![];
         HRule {
-            value: Value::Timestamp(Timestamp::from_timestamp(1000, 0).unwrap()),
+            value: Value::Timestamp(Timestamp::from_time_t(1000)),
             color: "#010203".parse().unwrap(),
             legend: None,
             dashes: Some(Dashes {

--- a/src/ops/graph/mod.rs
+++ b/src/ops/graph/mod.rs
@@ -6,6 +6,7 @@ pub mod elements;
 pub mod props;
 
 use crate::error::InvalidArgument;
+use crate::TimestampExt;
 use crate::{
     error::{get_rrd_error, RrdError, RrdResult},
     ops::{
@@ -69,15 +70,10 @@ pub fn graph(
     let graph_height = extract_info_value(&mut info, "graph_height", |v| v.into_count())?;
     let image_width = extract_info_value(&mut info, "image_width", |v| v.into_count())?;
     let image_height = extract_info_value(&mut info, "image_height", |v| v.into_count())?;
-    let graph_start =
-        extract_info_value(&mut info, "graph_start", |v| v.into_count()).map(|t| {
-            Timestamp::from_timestamp(t.try_into().expect("Graph start overflow"), 0)
-                .expect("Impossible graph start")
-        })?;
-    let graph_end = extract_info_value(&mut info, "graph_end", |v| v.into_count()).map(|t| {
-        Timestamp::from_timestamp(t.try_into().expect("Graph end overflow"), 0)
-            .expect("Impossible graph end")
-    })?;
+    let graph_start = extract_info_value(&mut info, "graph_start", |v| v.into_count())
+        .map(|t| Timestamp::from_time_t(t.try_into().expect("Graph start overflow")))?;
+    let graph_end = extract_info_value(&mut info, "graph_end", |v| v.into_count())
+        .map(|t| Timestamp::from_time_t(t.try_into().expect("Graph end overflow")))?;
     let value_min = extract_info_value(&mut info, "value_min", |v| v.into_value())?;
     let value_max = extract_info_value(&mut info, "value_max", |v| v.into_value())?;
 

--- a/src/ops/graph/props.rs
+++ b/src/ops/graph/props.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{InvalidArgument, RrdResult};
 use crate::ops::graph::Color;
+use crate::TimestampExt;
 use crate::{ops::graph::AppendArgs, Timestamp};
 use std::collections;
 
@@ -71,11 +72,11 @@ impl AppendArgs for TimeRange {
     fn append_to(&self, args: &mut Vec<String>) -> RrdResult<()> {
         if let Some(s) = &self.start {
             args.push("--start".to_string());
-            args.push(format!("{}", s.timestamp()));
+            args.push(format!("{}", s.as_time_t()));
         }
         if let Some(e) = &self.end {
             args.push("--end".to_string());
-            args.push(format!("{}", e.timestamp()));
+            args.push(format!("{}", e.as_time_t()));
         }
         if let Some(ss) = &self.step_seconds {
             args.push("--step".to_string());
@@ -835,8 +836,8 @@ mod tests {
     fn everything_set() {
         let props = GraphProps {
             time_range: TimeRange {
-                start: Some(chrono::DateTime::from_timestamp(1_000, 0).unwrap()),
-                end: Some(chrono::DateTime::from_timestamp(100_000, 0).unwrap()),
+                start: Some(Timestamp::from_time_t(1_000)),
+                end: Some(Timestamp::from_time_t(100_000)),
                 step_seconds: Some(60),
             },
             labels: Labels {

--- a/src/ops/update.rs
+++ b/src/ops/update.rs
@@ -1,6 +1,7 @@
 //! Update (i.e. add data to) an RRD.
 
 use crate::error::RrdError;
+use crate::TimestampExt;
 use crate::{
     error::{return_code_to_result, RrdResult},
     util::{path_to_str, ArrayOfStrings},
@@ -265,7 +266,7 @@ where
                     timestamp_arg.push('N');
                 }
                 BatchTime::Timestamp(ts) => {
-                    write!(timestamp_arg, "{}", ts.timestamp())
+                    write!(timestamp_arg, "{}", ts.as_time_t())
                         .expect("Writing to a String can't fail");
                 }
             }
@@ -306,10 +307,7 @@ mod tests {
 
         call_update_with_tuple_refs(
             &rrd_path,
-            &[(
-                Timestamp::from_timestamp(920804460, 0).unwrap().into(),
-                [100_u64.into()],
-            )],
+            &[(Timestamp::from_time_t(920804460).into(), [100_u64.into()])],
         )?;
 
         Ok(())
@@ -324,10 +322,7 @@ mod tests {
 
         call_update_with_tuple_vals(
             &rrd_path,
-            [(
-                Timestamp::from_timestamp(920804460, 0).unwrap().into(),
-                [100_u64.into()],
-            )],
+            [(Timestamp::from_time_t(920804460).into(), [100_u64.into()])],
         )?;
 
         Ok(())
@@ -336,7 +331,7 @@ mod tests {
     fn create(rrd_path: &Path) -> anyhow::Result<()> {
         create::create(
             rrd_path,
-            Timestamp::from_timestamp(920804400, 0).unwrap(),
+            Timestamp::from_time_t(920804400),
             time::Duration::from_secs(300),
             true,
             None,

--- a/tests/create.rs
+++ b/tests/create.rs
@@ -2,11 +2,31 @@ use itertools::Itertools;
 use rrd::{ops::create, ops::info, ConsolidationFn};
 use std::{collections, time};
 
+#[cfg(not(feature = "chrono"))]
+trait AsTimestamp {
+    fn timestamp(&self) -> i64;
+}
+
+#[cfg(not(feature = "chrono"))]
+impl AsTimestamp for std::time::SystemTime {
+    fn timestamp(&self) -> i64 {
+        self.duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+}
+
 #[test]
 fn create_all_ds_types() -> anyhow::Result<()> {
     let tempdir = tempfile::tempdir()?;
     let rrd_path = tempdir.path().join("rrd");
+
+    #[cfg(feature = "chrono")]
     let now = chrono::Utc::now();
+
+    #[cfg(not(feature = "chrono"))]
+    let now = std::time::SystemTime::now();
+
     create::create(
         &rrd_path,
         now,

--- a/tests/minimal_graph.rs
+++ b/tests/minimal_graph.rs
@@ -9,6 +9,23 @@ use rrd::{
 };
 use std::{path, time};
 
+#[cfg(not(feature = "chrono"))]
+trait FromTimestamp {
+    fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+#[cfg(not(feature = "chrono"))]
+impl FromTimestamp for Timestamp {
+    fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self> {
+        Some(
+            std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::new(secs.try_into().ok()?, nsecs),
+        )
+    }
+}
+
 #[test]
 fn minimal_graph() -> anyhow::Result<()> {
     let _ = env_logger::builder()

--- a/tests/tutorial.rs
+++ b/tests/tutorial.rs
@@ -9,6 +9,23 @@ use rrd::{
 };
 use std::time;
 
+#[cfg(not(feature = "chrono"))]
+trait FromTimestamp {
+    fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+#[cfg(not(feature = "chrono"))]
+impl FromTimestamp for Timestamp {
+    fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self> {
+        Some(
+            std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::new(secs.try_into().ok()?, nsecs),
+        )
+    }
+}
+
 /// Steps from https://oss.oetiker.ch/rrdtool/tut/rrdtutorial.en.html
 
 #[test]


### PR DESCRIPTION
This enables chrono by default but allows opt out when building without default features.